### PR TITLE
Even faster looting, update interface version

### DIFF
--- a/FasterLooting.lua
+++ b/FasterLooting.lua
@@ -1,28 +1,44 @@
 -- File: FasterLooting.lua
 -- Name: FasterLooting
--- Author: cannon
+-- Author: cannon, latenssi
 -- Description: Auto loots all items without the delay currently in Classic
--- Version: 1.1.1
+-- Version: 1.2.0
 
--- Time delay
-local delay = 0
 local DEBOUNCE_INTERVAL = 0.3
 
+local delay = 0
+local shouldFastLoot = false
+local LootFrame_OnEvent_default = LootFrame:GetScript("OnEvent")
 
 -- Fast loot function
 function FastLoot()
     if GetTime() - delay >= DEBOUNCE_INTERVAL then
-        delay = GetTime()
-        if GetCVarBool("autoLootDefault") ~= IsModifiedClick("AUTOLOOTTOGGLE") then
-            for i = GetNumLootItems(), 1, -1 do
-                LootSlot(i)
-            end
-            delay = GetTime()
+        for i = GetNumLootItems(), 1, -1 do
+            LootSlot(i)
         end
+        delay = GetTime()
     end
 end
 
--- event frame
-local faster = CreateFrame("Frame")
-faster:RegisterEvent("LOOT_READY")
-faster:SetScript("OnEvent", FastLoot)
+function LootFrame_OnEvent_modified(...)
+    local _, event = ...
+
+    if event == "LOOT_READY" then
+        shouldFastLoot = GetCVarBool("autoLootDefault") ~= IsModifiedClick("AUTOLOOTTOGGLE")
+    elseif event == "LOOT_CLOSED" then
+        -- Reset
+        shouldFastLoot = false
+    end
+
+    if event == "LOOT_READY" and shouldFastLoot then
+        -- Run our FastLoot handler
+        -- Note: Ignoring all LootFrame registered events to prevent displaying the loot window etc.
+        -- Note: This is run on LOOT_READY so we do not need to wait for the LOOT_OPENED event
+        FastLoot()
+    elseif not shouldFastLoot then
+        -- Run the default handler
+        LootFrame_OnEvent_default(...)
+    end
+end
+
+LootFrame:SetScript("OnEvent", LootFrame_OnEvent_modified)

--- a/FasterLooting.toc
+++ b/FasterLooting.toc
@@ -1,6 +1,6 @@
-## Interface: 11303
+## Interface: 11305
 ## Title: FasterLooting
-## Author: cannon
+## Author: cannon, latenssi
 ## Notes: Auto loots all items without the delay currently in Classic
-## Version: 1.1.2
+## Version: 1.2.0
 FasterLooting.lua


### PR DESCRIPTION
This PR updates the interface version and makes looting faster by ignoring all other LootFrame events if we are "Fast Looting". For example the loot window does not show up at all with this PR.